### PR TITLE
support TLS 1.2

### DIFF
--- a/src/GregClient/GregClient.cs
+++ b/src/GregClient/GregClient.cs
@@ -19,6 +19,10 @@ namespace Greg
 
         public GregClient(IAuthProvider provider, string packageManagerUrl)
         {
+            // added to enable TLS1.2 compatability - this is required as we target .net 4.5.
+            // TODO can be removed when we upgrade to .net4.7
+            // documented here: https://medium.com/@kyle.gagnet/your-net-code-could-stop-working-in-june-afb35fbf29ca
+
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
             _authProvider = provider;
             _client = new RestClient(packageManagerUrl);

--- a/src/GregClient/GregClient.cs
+++ b/src/GregClient/GregClient.cs
@@ -19,8 +19,10 @@ namespace Greg
 
         public GregClient(IAuthProvider provider, string packageManagerUrl)
         {
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
             _authProvider = provider;
             _client = new RestClient(packageManagerUrl);
+
         }
 
         private IRestResponse ExecuteInternal(Request m)


### PR DESCRIPTION
because the package manager client is currently built targeting .net 4.5 (as are other dynamo dlls) - simplest way to support tls 1.2 is to OR it with the the current security protocols the `servicePointManager` supports.

https://docs.microsoft.com/en-us/dotnet/api/system.net.servicepointmanager?redirectedfrom=MSDN&view=netframework-4.7.2

After this small change - rebuilding this dll, and adding it to dynamoCore's directory, wireshark shows the following for interactions with the dev package manager as of today.

![image](https://user-images.githubusercontent.com/508936/44534560-1ae8cd00-a6c6-11e8-9354-084bbca9b02c.png)

@Dewb @ramramps @Racel 

