### PR TITLE
Remove Ionic.Zip and use System.IO.Compression to handle zip/unzip

### DIFF
--- a/src/GregClient/GregClient.csproj
+++ b/src/GregClient/GregClient.csproj
@@ -34,10 +34,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Ionic.Zip, Version=1.9.1.8, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Unofficial.Ionic.Zip.1.9.1.8\lib\Ionic.Zip.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
@@ -48,6 +44,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AuthProviders\BasicProvider.cs" />

--- a/src/GregClient/NuGet/GregClient.nuspec
+++ b/src/GregClient/NuGet/GregClient.nuspec
@@ -9,11 +9,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The Dynamo Package Manager .Net Client.</description>
     <releaseNotes>The Dynamo Package Manager .Net Client.</releaseNotes>
-    <copyright>Copyright 2016</copyright>
+    <copyright>Copyright 2018</copyright>
     <tags>dynamo package greg</tags>
     <dependencies>
         <dependency id="RestSharp" version="105.2.3" />
-        <dependency id="Unofficial.Ionic.Zip" version="1.9.1.8" />
         <dependency id="Newtonsoft.Json" version="8.0.3" />
     </dependencies>
   </metadata>

--- a/src/GregClient/Properties/AssemblyInfo.cs
+++ b/src/GregClient/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.1.*")]
 
 [assembly: InternalsVisibleTo("GregClientSandbox")]

--- a/src/GregClient/Utility/FileUtilities.cs
+++ b/src/GregClient/Utility/FileUtilities.cs
@@ -99,18 +99,16 @@ namespace Greg.Utility
         /// <summary>
         /// Make a zip file from a collection of files
         /// </summary>
-        /// <param name="paths">A list of filepaths</param>
-        /// <returns>False if the process fails, true otherwise</returns>
-        /// <throws>FileNotFoundException, ZipException</throws>
+        /// <param name="filePaths">A list of filepaths</param>
         public static string Zip(IEnumerable<string> filePaths)
         {
             var zipPath = GetTempZipPath();
 
             using (var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create))
             {
-                foreach (var filename in filePaths)
-                {
-                    ZipFileExtensions.CreateEntryFromFile(zip, filename, filename);
+                foreach (var filePath in filePaths)
+                {   
+                    zip.CreateEntryFromFile(filePath, filePath);
                 }
             }
 
@@ -120,14 +118,13 @@ namespace Greg.Utility
         /// <summary>
         /// Make a zip file from a collection of files
         /// </summary>
-        /// <param name="paths">A list of filepaths</param>
-        /// <returns>False if the process fails, true otherwise</returns>
-        /// <throws>FileNotFoundException, ZipException</throws>
+        /// <param name="directory">A directory - should be the package root path</param>
         public static string Zip(string directory)
         {
-            return Zip(Directory.EnumerateFiles(directory, "*.*", SearchOption.AllDirectories));
+            var zipPath = GetTempZipPath();
+            ZipFile.CreateFromDirectory(directory, zipPath);
+            return zipPath;
         }
-
 
         /// <summary>
         /// Given a path to a zip, extracts it and returns the 

--- a/src/GregClient/packages.config
+++ b/src/GregClient/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net40" />
+  <package id="NuGet.CommandLine" version="4.7.1" targetFramework="net45" developmentDependency="true" />
   <package id="RestSharp" version="105.2.3" targetFramework="net40" />
-  <package id="Unofficial.Ionic.Zip" version="1.9.1.8" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Unzipping downloaded packages has been tested, zipping is untested until I am back on a machine with Revit/OAuth.

This bumps the Greg nuget version to 1.1.x.