### PR TITLE
Use System.IO.Compression for unzip only, leaving zip to Ionic.Zip

### DIFF
--- a/src/GregClient/GregClient.csproj
+++ b/src/GregClient/GregClient.csproj
@@ -48,6 +48,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AuthProviders\BasicProvider.cs" />


### PR DESCRIPTION
This is a minimal safe change to workaround the decompression bugs in Ionic.Zip. This PR only changes the Unzip function to use System.IO.Compression, and leaves the zipping features unchanged from previous versions.

This change keeps the Greg nuget version at 1.0.x.