### PR TITLE
add net45 targeting to Greg.dll so we can consume latest fixes in older Dynamo versions

### DIFF
--- a/src/GregClient.sln
+++ b/src/GregClient.sln
@@ -4,8 +4,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 15.0.28010.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GregClient", "GregClient\GregClient.csproj", "{644207B4-7E7F-474A-952E-3453960D8A01}"
+	ProjectSection(ProjectDependencies) = postProject
+		{B45317C9-5509-47D6-832D-24E20BF640A0} = {B45317C9-5509-47D6-832D-24E20BF640A0}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GregClientSandbox", "GregClientSandbox\GregClientSandbox.csproj", "{12F6037C-A559-408E-AD10-4FBF05285AC3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GregClient_net45", "GregClient_net45\GregClient_net45.csproj", "{B45317C9-5509-47D6-832D-24E20BF640A0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +26,10 @@ Global
 		{12F6037C-A559-408E-AD10-4FBF05285AC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{12F6037C-A559-408E-AD10-4FBF05285AC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{12F6037C-A559-408E-AD10-4FBF05285AC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B45317C9-5509-47D6-832D-24E20BF640A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B45317C9-5509-47D6-832D-24E20BF640A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B45317C9-5509-47D6-832D-24E20BF640A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B45317C9-5509-47D6-832D-24E20BF640A0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/GregClient/CreateNugetPackage.ps1
+++ b/src/GregClient/CreateNugetPackage.ps1
@@ -23,9 +23,7 @@ if(!(Test-Path -Path $nuget\tools)){
     New-Item -ItemType directory -Path $nuget\tools
 }
 
-copy $out\Greg_net45.dll $nuget\lib\net45\
-Remove-Item -Path $nuget\lib\net45\Greg.dll -ErrorAction Ignore
-Rename-Item -path $nuget\lib\net45\Greg_net45.dll -NewName Greg.dll
+copy $out\net45\Greg.dll $nuget\lib\net45\
 
 copy $out\Greg.dll $nuget\lib\net47\
 

--- a/src/GregClient/CreateNugetPackage.ps1
+++ b/src/GregClient/CreateNugetPackage.ps1
@@ -6,6 +6,9 @@
 if(!(Test-Path -Path $nuget\lib\net47\)){
     New-Item -ItemType directory -Path $nuget\lib\net47\
 }
+if(!(Test-Path -Path $nuget\lib\net45\)){
+    New-Item -ItemType directory -Path $nuget\lib\net45\
+}
 
 
 if(!(Test-Path -Path $nuget\content)){
@@ -19,6 +22,10 @@ if(!(Test-Path -Path $nuget\content\controllers)){
 if(!(Test-Path -Path $nuget\tools)){
     New-Item -ItemType directory -Path $nuget\tools
 }
+
+copy $out\Greg_net45.dll $nuget\lib\net45\
+Remove-Item -Path $nuget\lib\net45\Greg.dll -ErrorAction Ignore
+Rename-Item -path $nuget\lib\net45\Greg_net45.dll -NewName Greg.dll
 
 copy $out\Greg.dll $nuget\lib\net47\
 

--- a/src/GregClient/GregClient.csproj
+++ b/src/GregClient/GregClient.csproj
@@ -52,6 +52,7 @@
     <Compile Include="AuthProviders\LoginState.cs" />
     <Compile Include="IGregClient.cs" />
     <Compile Include="PackageManagerClient.cs" />
+    <Compile Include="Properties\globalVersionInfo.cs" />
     <Compile Include="Requests\BanPackage.cs" />
     <Compile Include="Requests\Deprecate.cs" />
     <Compile Include="Requests\Downvote.cs" />

--- a/src/GregClient/Properties/AssemblyInfo.cs
+++ b/src/GregClient/Properties/AssemblyInfo.cs
@@ -22,16 +22,4 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b5ebb49a-bfb3-4aff-8411-2f42b0e6854e")]
 
-// version information for an assembly consists of the following four values:
-//
-//      Major version
-//      Minor version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.*")]
-
 [assembly: InternalsVisibleTo("GregClientSandbox")]

--- a/src/GregClient/Properties/globalVersionInfo.cs
+++ b/src/GregClient/Properties/globalVersionInfo.cs
@@ -1,0 +1,6 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+
+[assembly: AssemblyVersion("1.1.*")]

--- a/src/GregClient_net45/GregClient_net45.csproj
+++ b/src/GregClient_net45/GregClient_net45.csproj
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B45317C9-5509-47D6-832D-24E20BF640A0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Greg</RootNamespace>
+    <AssemblyName>Greg_net45</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>false</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\GregClient\AuthProviders\BasicProvider.cs">
+      <Link>AuthProviders\BasicProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\AuthProviders\IAuthProvider.cs">
+      <Link>AuthProviders\IAuthProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\AuthProviders\LoginState.cs">
+      <Link>AuthProviders\LoginState.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\GregClient.cs">
+      <Link>GregClient.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\IGregClient.cs">
+      <Link>IGregClient.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\PackageManagerClient.cs">
+      <Link>PackageManagerClient.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Properties\globalVersionInfo.cs">
+      <Link>Properties\globalVersionInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\BanPackage.cs">
+      <Link>Requests\BanPackage.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\Deprecate.cs">
+      <Link>Requests\Deprecate.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\Downvote.cs">
+      <Link>Requests\Downvote.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\HeaderCollectionDownload.cs">
+      <Link>Requests\HeaderCollectionDownload.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\HeaderDownload.cs">
+      <Link>Requests\HeaderDownload.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\JSONRequest.cs">
+      <Link>Requests\JSONRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\PackageDownload.cs">
+      <Link>Requests\PackageDownload.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\PackageManagerRequest.cs">
+      <Link>Requests\PackageManagerRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\PackageReferenceRequest.cs">
+      <Link>Requests\PackageReferenceRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\PackageUpload.cs">
+      <Link>Requests\PackageUpload.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\PackageUploadRequestBody.cs">
+      <Link>Requests\PackageUploadRequestBody.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\PackageVersionUpload.cs">
+      <Link>Requests\PackageVersionUpload.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\PackageVersionUploadRequestBody.cs">
+      <Link>Requests\PackageVersionUploadRequestBody.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\Request.cs">
+      <Link>Requests\Request.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\RequestBody.cs">
+      <Link>Requests\RequestBody.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\Search.cs">
+      <Link>Requests\Search.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\TermsOfUse.cs">
+      <Link>Requests\TermsOfUse.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\Undeprecate.cs">
+      <Link>Requests\Undeprecate.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\Upvote.cs">
+      <Link>Requests\Upvote.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\ValidateAuth.cs">
+      <Link>Requests\ValidateAuth.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\WhitelistHeaderCollectionDownload.cs">
+      <Link>Requests\WhitelistHeaderCollectionDownload.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Responses\Responses.cs">
+      <Link>Responses\Responses.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Utility\FileUtilities.cs">
+      <Link>Utility\FileUtilities.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Utility\PackageUtilities.cs">
+      <Link>Utility\PackageUtilities.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Utility\Utilities.cs">
+      <Link>Utility\Utilities.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Whitelist.cs">
+      <Link>Whitelist.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\GregClient\packages.config">
+      <Link>packages.config</Link>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/GregClient_net45/GregClient_net45.csproj
+++ b/src/GregClient_net45/GregClient_net45.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Greg</RootNamespace>
-    <AssemblyName>Greg_net45</AssemblyName>
+    <AssemblyName>Greg</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>false</Deterministic>
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\Debug\</OutputPath>
+    <OutputPath>..\..\bin\Debug\net45</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\Release\</OutputPath>
+    <OutputPath>..\..\bin\Release\net45</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/GregClient_net45/Properties/AssemblyInfo.cs
+++ b/src/GregClient_net45/Properties/AssemblyInfo.cs
@@ -5,12 +5,12 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("GregClient_net45")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyTitle("Greg")]
+[assembly: AssemblyDescription("The Dynamo Package Manager .NET client.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("GregClient_net45")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyCompany("Autodesk, Inc.")]
+[assembly: AssemblyProduct("Greg")]
+[assembly: AssemblyCopyright("Copyright © Autodesk, Inc. 2019")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/GregClient_net45/Properties/AssemblyInfo.cs
+++ b/src/GregClient_net45/Properties/AssemblyInfo.cs
@@ -1,0 +1,24 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GregClient_net45")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("GregClient_net45")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b45317c9-5509-47d6-832d-24e20bf640a0")]
+


### PR DESCRIPTION
![Screen Shot 2019-05-09 at 3 15 13 PM](https://user-images.githubusercontent.com/508936/57480280-44a24e00-726d-11e9-8111-7a95b81bbeaf.png)

This PR adds a new project to the package manager client solution - 
a legacy GregClient_net45 project. This is not ideal. 

At first I tried to use the `<targetFrameworks>` attribute as described here:
https://docs.microsoft.com/en-us/dotnet/standard/frameworks

sounds great .... it's not so simple of course - nuget restore is immediately busted. The solution crashes VS 2017(latest updates) whenever you try to clean or rebuild the solution. I found a few github issues reporting similar things from last year. If this was a project we updated more or if we intended to have more multi targeting I might look further, but I'm just not sure this feature of csproj files works very well with vs yet.

Instead I just added this extra project - it links to all the existing files of the regular GregClient.csproj, but targets `net45`.

I added a `globalAssemblyVersion.cs` file so the version numbers of both dlls are the same -

I also added some copy and rename steps to the nuget pack script to create a `net45` folder with this dll.

⚠️ TODO:

- [x] I have not yet tried actually importing / referencing this dll from Dynamo/DynamoRevit which is what I will need to do next to verify this works.

### Reviewers:
@aparajit-pratap 
@scottmitchell 
