### PR TITLE
net45 build should enforce TLS 1.2 always

### DIFF
--- a/src/GregClient/GregClient.cs
+++ b/src/GregClient/GregClient.cs
@@ -19,8 +19,10 @@ namespace Greg
 
         public GregClient(IAuthProvider provider, string packageManagerUrl)
         {
-           
 
+#if LT_NET47
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+#else
             // https://stackoverflow.com/questions/2819934/detect-windows-version-in-net
             // if the current OS is windows 7 or lower
             // set TLS to 1.2.
@@ -29,6 +31,7 @@ namespace Greg
             {
                 ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
             }
+#endif
             _authProvider = provider;
             _client = new RestClient(packageManagerUrl);
         }

--- a/src/GregClient_net45/GregClient_net45.csproj
+++ b/src/GregClient_net45/GregClient_net45.csproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug\net45</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;LT_NET47</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
net 45 version of Greg should not let the OS decided what TLS to use and should always enforce TLS 1.2

.net 47 dll
![Screen Shot 2019-07-15 at 9 22 36 PM](https://user-images.githubusercontent.com/508936/61259172-092d6f80-a747-11e9-8b70-59d898295e91.png)

.net 45 dll

![Screen Shot 2019-07-15 at 9 23 09 PM](https://user-images.githubusercontent.com/508936/61259173-092d6f80-a747-11e9-89f9-c393a6adb45a.png)

@QilongTang @Dewb