### PR TITLE
add back the old constructors and use them

### DIFF
--- a/src/GregClient/Requests/PackageUploadRequestBody.cs
+++ b/src/GregClient/Requests/PackageUploadRequestBody.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Greg.Requests
 {
@@ -9,7 +10,25 @@ namespace Greg.Requests
             string contents, string engine, string engineVersion,
             string metadata, string group, IEnumerable<PackageDependency> dependencies,
             string siteUrl, string repositoryUrl, bool containsBinaries, 
-            IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies)
+            IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies):
+
+            this(name,version,description,
+                keywords,license,
+                contents,engine,engineVersion, 
+                metadata,group,dependencies,
+                siteUrl,repositoryUrl,containsBinaries,
+                nodeLibraryNames)
+        {
+            this.host_dependencies = hostDependencies;
+        }
+
+        [Obsolete("This constructor will be removed in a future release of packageManagerClient.")]
+        public PackageUploadRequestBody(string name, string version, string description,
+           IEnumerable<string> keywords, string license,
+           string contents, string engine, string engineVersion,
+           string metadata, string group, IEnumerable<PackageDependency> dependencies,
+           string siteUrl, string repositoryUrl, bool containsBinaries,
+           IEnumerable<string> nodeLibraryNames)
         {
             this.name = name;
             this.version = version;
@@ -25,7 +44,6 @@ namespace Greg.Requests
             this.repository_url = repositoryUrl;
             this.contains_binaries = containsBinaries;
             this.node_libraries = nodeLibraryNames;
-            this.host_dependencies = hostDependencies;
 
             this.license = license;
         }

--- a/src/GregClient/Requests/PackageVersionUploadRequestBody.cs
+++ b/src/GregClient/Requests/PackageVersionUploadRequestBody.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Greg.Requests
 {
@@ -7,6 +8,42 @@ namespace Greg.Requests
         internal PackageVersionUploadRequestBody()
         {
 
+        }
+
+
+        /// <summary>
+        /// Constructor which can be used to set hostDependencies
+        /// </summary>
+        /// <param name="name">Package name</param>
+        /// <param name="version">Package version</param>
+        /// <param name="description">Package description</param>
+        /// <param name="keywords">Package keywords for quick identification</param>
+        /// <param name="contents">Package content description</param>
+        /// <param name="engine">Package engine name, usually is set to Dynamo</param>
+        /// <param name="engineVersion">Package engine version, usually is set to use Dynamo version</param>
+        /// <param name="metadata"></param>
+        /// <param name="group"></param>
+        /// <param name="dependencies">Package dependencies</param>
+        /// <param name="siteUrl"></param>
+        /// <param name="repositoryUrl"></param>
+        /// <param name="containsBinaries">boolean flag indicating if the package contains binaries</param>
+        /// <param name="nodeLibraryNames"></param>
+        /// <param name="hostDependencies"> external programs this package depends on.</param>
+        public PackageVersionUploadRequestBody(string name, string version, string description,
+          IEnumerable<string> keywords,
+          string contents, string engine, string engineVersion,
+          string metadata, string group, IEnumerable<PackageDependency> dependencies,
+          string siteUrl, string repositoryUrl, bool containsBinaries,
+          IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies) :
+
+          this(name, version, description,
+              keywords,
+              contents, engine, engineVersion,
+              metadata, group, dependencies,
+              siteUrl, repositoryUrl, containsBinaries,
+              nodeLibraryNames)
+        {
+            this.host_dependencies = hostDependencies;
         }
 
         /// <summary>
@@ -26,12 +63,12 @@ namespace Greg.Requests
         /// <param name="repositoryUrl"></param>
         /// <param name="containsBinaries">boolean flag indicating if the package contains binaries</param>
         /// <param name="nodeLibraryNames"></param>
-        /// <param name="hostDependencies">Package host dependencies</param>
+        [Obsolete("This constructor will be removed in a future release of packageManagerClient.")]
         public PackageVersionUploadRequestBody(string name, string version, string description,
             IEnumerable<string> keywords, string contents, string engine, string engineVersion,
             string metadata, string group, IEnumerable<PackageDependency> dependencies,
             string siteUrl, string repositoryUrl, bool containsBinaries,
-            IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies)
+            IEnumerable<string> nodeLibraryNames)
         {
             this.name = name;
             this.version = version;
@@ -47,7 +84,6 @@ namespace Greg.Requests
             this.repository_url = repositoryUrl;
             this.contains_binaries = containsBinaries;
             this.node_libraries = nodeLibraryNames;
-            this.host_dependencies = hostDependencies;
         }
 
         public string file_hash { get; set; }


### PR DESCRIPTION
This PR reverts some API changes by adding back old constructors:

https://www.fuget.org/packages/Greg/1.2.7121.21318/lib/net47/diff/1.1.7074.39323/

@QilongTang PTAL - if this is good to go I'll push a new version of this to nuget, and we can integrate whenever.