### PR TITLE
add empty default constructor for json.net to use.

### DIFF
--- a/src/GregClient/Requests/PackageUploadRequestBody.cs
+++ b/src/GregClient/Requests/PackageUploadRequestBody.cs
@@ -1,10 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Greg.Requests
 {
     public class PackageUploadRequestBody : PackageVersionUploadRequestBody
     {
+        //!!!! it is important to keep this in mind:
+        //https://stackoverflow.com/questions/33107789/json-net-deserialization-constructor-vs-property-rules
+
+        /// <summary>
+        /// Default constructor - should only be used for deserialization with json.net.
+        /// json.net will construct an empty object and fill it with properties with matching names.
+        /// </summary>
+        public PackageUploadRequestBody()
+        {
+
+        }
         public PackageUploadRequestBody(string name, string version, string description,
             IEnumerable<string> keywords, string license,
             string contents, string engine, string engineVersion,

--- a/src/GregClient/Requests/PackageUploadRequestBody.cs
+++ b/src/GregClient/Requests/PackageUploadRequestBody.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Greg.Requests
 {
@@ -9,7 +10,25 @@ namespace Greg.Requests
             string contents, string engine, string engineVersion,
             string metadata, string group, IEnumerable<PackageDependency> dependencies,
             string siteUrl, string repositoryUrl, bool containsBinaries, 
-            IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies)
+            IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies):
+
+            this(name,version,description,
+                keywords,license,
+                contents,engine,engineVersion, 
+                metadata,group,dependencies,
+                siteUrl,repositoryUrl,containsBinaries,
+                nodeLibraryNames)
+        {
+            this.host_dependencies = hostDependencies;
+        }
+
+        [Obsolete("This constructor will be removed in a future release of packageManagerClient.")]
+        public PackageUploadRequestBody(string name, string version, string description,
+           IEnumerable<string> keywords, string license,
+           string contents, string engine, string engineVersion,
+           string metadata, string group, IEnumerable<PackageDependency> dependencies,
+           string siteUrl, string repositoryUrl, bool containsBinaries,
+           IEnumerable<string> nodeLibraryNames)
         {
             this.name = name;
             this.version = version;
@@ -25,7 +44,6 @@ namespace Greg.Requests
             this.repository_url = repositoryUrl;
             this.contains_binaries = containsBinaries;
             this.node_libraries = nodeLibraryNames;
-            this.host_dependencies = hostDependencies;
 
             this.license = license;
         }

--- a/src/GregClient/Requests/PackageVersionUploadRequestBody.cs
+++ b/src/GregClient/Requests/PackageVersionUploadRequestBody.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Greg.Requests
 {
@@ -7,6 +8,42 @@ namespace Greg.Requests
         internal PackageVersionUploadRequestBody()
         {
 
+        }
+
+
+        /// <summary>
+        /// Constructor which can be used to set hostDependencies
+        /// </summary>
+        /// <param name="name">Package name</param>
+        /// <param name="version">Package version</param>
+        /// <param name="description">Package description</param>
+        /// <param name="keywords">Package keywords for quick identification</param>
+        /// <param name="contents">Package content description</param>
+        /// <param name="engine">Package engine name, usually is set to Dynamo</param>
+        /// <param name="engineVersion">Package engine version, usually is set to use Dynamo version</param>
+        /// <param name="metadata"></param>
+        /// <param name="group"></param>
+        /// <param name="dependencies">Package dependencies</param>
+        /// <param name="siteUrl"></param>
+        /// <param name="repositoryUrl"></param>
+        /// <param name="containsBinaries">boolean flag indicating if the package contains binaries</param>
+        /// <param name="nodeLibraryNames"></param>
+        /// <param name="hostDependencies"> external programs this package depends on.</param>
+        public PackageVersionUploadRequestBody(string name, string version, string description,
+          IEnumerable<string> keywords,
+          string contents, string engine, string engineVersion,
+          string metadata, string group, IEnumerable<PackageDependency> dependencies,
+          string siteUrl, string repositoryUrl, bool containsBinaries,
+          IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies) :
+
+          this(name, version, description,
+              keywords,
+              contents, engine, engineVersion,
+              metadata, group, dependencies,
+              siteUrl, repositoryUrl, containsBinaries,
+              nodeLibraryNames)
+        {
+            this.host_dependencies = hostDependencies;
         }
 
         /// <summary>
@@ -26,12 +63,12 @@ namespace Greg.Requests
         /// <param name="repositoryUrl"></param>
         /// <param name="containsBinaries">boolean flag indicating if the package contains binaries</param>
         /// <param name="nodeLibraryNames"></param>
-        /// <param name="hostDependencies">Package host dependencies</param>
+        [Obsolete("This constructor will be removed in a future release of packageManagerClient.")]
         public PackageVersionUploadRequestBody(string name, string version, string description,
             IEnumerable<string> keywords, string contents, string engine, string engineVersion,
             string metadata, string group, IEnumerable<PackageDependency> dependencies,
             string siteUrl, string repositoryUrl, bool containsBinaries,
-            IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies)
+            IEnumerable<string> nodeLibraryNames)
         {
             this.name = name;
             this.version = version;
@@ -47,7 +84,6 @@ namespace Greg.Requests
             this.repository_url = repositoryUrl;
             this.contains_binaries = containsBinaries;
             this.node_libraries = nodeLibraryNames;
-            this.host_dependencies = hostDependencies;
         }
 
         public string file_hash { get; set; }


### PR DESCRIPTION
@QilongTang 

In Dynamo we make a call like this:
```
   var pkgHeader = File.ReadAllText(headerPath);
   var body = JsonConvert.DeserializeObject<PackageUploadRequestBody>(pkgHeader);
```

which deserializes some json text into a packageUploadRequest which we then turn into a package.

This `DeserializeObject` call requires that the object type it tries to deserialize has a constructor which can be called by Json.net.

Since we now have two constructors (old and new api) it doesn't know which to call and throws. So we add an empty constructor, Json.net prefers this, calls it, and then iterates over all the properties in the json trying to call public setters. It just so happens that works great because all the property names in the json match the property names in c#.
