### PR TITLE
Set timout propery to RestRequests

### DIFF
--- a/src/GregClient/App.config
+++ b/src/GregClient/App.config
@@ -2,6 +2,7 @@
 <configuration>
   <appSettings>
     <add key="EnableDebugLogs" value="false" />
+    <add key="Timeout" value="300" />
   </appSettings>
   <startup>
      <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>

--- a/src/GregClient/GregClient.cs
+++ b/src/GregClient/GregClient.cs
@@ -2,6 +2,7 @@
 using Greg.Requests;
 using Greg.Responses;
 using RestSharp;
+using System;
 
 namespace Greg
 {
@@ -57,6 +58,22 @@ namespace Greg
                 AuthProvider.SignRequest(ref reqToSign, _client);
                 req.Resource = reqToSign.Resource;
             }
+
+            try
+            {
+                // Allow users to override the default Timeout setting in RestRequests
+                var timeoutSetting = Utility.AppSettingMgr.GetItem("Timeout");
+                if (timeoutSetting != null)
+                {
+                    // Timeout App Settings is in seconds.
+                    // RestRequest.Timeout is in milliseconds.
+                    req.Timeout = Convert.ToInt32(timeoutSetting.Value) * 1000;// get milliseconds
+                }
+            }
+            catch
+            {
+            }
+
             var restResp = _client.Execute(req);
             Utility.DebugLogger.LogResponse(restResp);
             return restResp;

--- a/src/GregClient/GregClient.cs
+++ b/src/GregClient/GregClient.cs
@@ -67,7 +67,12 @@ namespace Greg
                 {
                     // Timeout App Settings is in seconds.
                     // RestRequest.Timeout is in milliseconds.
-                    req.Timeout = Convert.ToInt32(timeoutSetting.Value) * 1000;// get milliseconds
+                    var userVal = Convert.ToInt32(timeoutSetting.Value);
+                    // Sanity check.
+                    if (userVal >= 0 && userVal < 86400/*24 hours*/)
+                    {
+                        req.Timeout = Convert.ToInt32(timeoutSetting.Value) * 1000;// get milliseconds
+                    }
                 }
             }
             catch

--- a/src/GregClient/Requests/JSONRequest.cs
+++ b/src/GregClient/Requests/JSONRequest.cs
@@ -8,8 +8,18 @@ namespace Greg.Requests
 {
     public abstract class JsonRequest : Request
     {
+        static protected int Timeout = 300000;// Default timeout for JsonRequests, in milliseconds
+
+        // Initialize the common RestRequest properties.
+        // Ex: Timeout property
+        internal void InitReqParams(ref RestRequest request)
+        {
+            request.Timeout = Timeout;
+        }
+
         internal override void Build(ref RestRequest request)
         {
+            InitReqParams(ref request);
             request.RequestFormat = DataFormat.Json;
             request.AddBody(this.RequestBody);
         }

--- a/src/GregClient/Requests/PackageUpload.cs
+++ b/src/GregClient/Requests/PackageUpload.cs
@@ -43,6 +43,8 @@ namespace Greg.Requests
 
         internal override void Build(ref RestRequest request)
         {
+            InitReqParams(ref request);
+
             // zip up and get hash for zip
             if (Files != null)
                 ZipFile = FileUtilities.Zip(Files);

--- a/src/GregClient/Requests/PackageVersionUpload.cs
+++ b/src/GregClient/Requests/PackageVersionUpload.cs
@@ -40,6 +40,8 @@ namespace Greg.Requests
 
         internal override void Build(ref RestRequest request)
         {
+            InitReqParams(ref request);
+
             // zip up and get hash for zip
             if (Files != null)
                 ZipFile = FileUtilities.Zip(Files);

--- a/src/GregClient/Utility/Utilities.cs
+++ b/src/GregClient/Utility/Utilities.cs
@@ -9,6 +9,24 @@ using System.Text;
 
 namespace Greg.Utility
 {
+    public static class AppSettingMgr
+    {
+        public static KeyValueConfigurationElement GetItem(String key)
+        {
+            try
+            {
+                var dllPath = new Uri(Assembly.GetExecutingAssembly().GetName().CodeBase).LocalPath;
+                var config = ConfigurationManager.OpenExeConfiguration(dllPath);
+                var enableDebugLogsSetting = config.AppSettings.Settings[key];
+                return enableDebugLogsSetting;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+
     public static class DebugLogger
     {
         private static readonly bool enabled = false;
@@ -19,11 +37,7 @@ namespace Greg.Utility
         {
             try
             {
-                var enableDebugLogsKey = "EnableDebugLogs";
-
-                var dllPath = new Uri(Assembly.GetExecutingAssembly().GetName().CodeBase).LocalPath;
-                var config = ConfigurationManager.OpenExeConfiguration(dllPath);
-                var enableDebugLogsSetting = config.AppSettings.Settings[enableDebugLogsKey];
+                var enableDebugLogsSetting = AppSettingMgr.GetItem("EnableDebugLogs");
                 if (enableDebugLogsSetting != null && Convert.ToBoolean(enableDebugLogsSetting.Value))
                 {
                     enabled = true;

--- a/src/GregClient/Utility/Utilities.cs
+++ b/src/GregClient/Utility/Utilities.cs
@@ -20,8 +20,10 @@ namespace Greg.Utility
                 var enableDebugLogsSetting = config.AppSettings.Settings[key];
                 return enableDebugLogsSetting;
             }
-            catch
+            catch(Exception ex)
             {
+                Console.WriteLine("The referenced configuration item, {0}, could not be retrieved", key);
+                Console.WriteLine(ex.Message);
                 return null;
             }
         }


### PR DESCRIPTION
Issue:
Large packages are failing on upload.
Package size around 85 Mb takes over 100 seconds to upload.
The default RestRequest.Timeout is 100 seconds. (https://docs.microsoft.com/en-us/dotnet/api/system.net.httpwebrequest.timeout?redirectedfrom=MSDN&view=netframework-4.8#System_Net_HttpWebRequest_Timeout)

Solution:
Set the default Timeout to 300 seconds and also add possibility to increase Timeout from App settings.