### PR TITLE
Expose endpoints to get package version metadata

### DIFF
--- a/src/GregClient/Converters/DependencyConverter.cs
+++ b/src/GregClient/Converters/DependencyConverter.cs
@@ -1,0 +1,51 @@
+﻿using Greg.Responses;
+using Newtonsoft.Json;
+using System;
+
+namespace Greg.Converters
+{
+    /// <summary>
+    /// Custom converter that supports deserializing a Dependency from either:
+    /// - a string, which is interpreted as the id of the dependency
+    /// - an object having the expected properties, which is the default behavior
+    /// </summary>
+    public class DependencyConverter : JsonConverter
+    {
+        public override bool CanWrite
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Dependency);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.ValueType == typeof(string))
+            {
+                // This is interpreted as the id of the dependency.
+                Dependency dep = (Dependency)existingValue ?? new Dependency();
+                dep._id = (string)reader.Value;
+                return dep;
+            }
+            else
+            {
+                // Use the default deserialization behavior.
+                existingValue = existingValue ?? serializer.ContractResolver.ResolveContract(objectType).DefaultCreator();
+                serializer.Populate(reader, existingValue);
+                return existingValue;
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            // Not needed as CanWrite is false.
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/GregClient/GregClient.csproj
+++ b/src/GregClient/GregClient.csproj
@@ -51,12 +51,14 @@
     <Compile Include="AuthProviders\BasicProvider.cs" />
     <Compile Include="AuthProviders\IAuthProvider.cs" />
     <Compile Include="AuthProviders\LoginState.cs" />
+    <Compile Include="Converters\DependencyConverter.cs" />
     <Compile Include="IGregClient.cs" />
     <Compile Include="PackageManagerClient.cs" />
     <Compile Include="Properties\globalVersionInfo.cs" />
     <Compile Include="Requests\BanPackage.cs" />
     <Compile Include="Requests\Deprecate.cs" />
     <Compile Include="Requests\Downvote.cs" />
+    <Compile Include="Requests\HeaderVersionDownload.cs" />
     <Compile Include="Requests\Hosts.cs" />
     <Compile Include="Requests\PackageManagerRequest.cs" />
     <Compile Include="Requests\PackageReferenceRequest.cs" />

--- a/src/GregClient/Requests/HeaderVersionDownload.cs
+++ b/src/GregClient/Requests/HeaderVersionDownload.cs
@@ -2,6 +2,9 @@
 
 namespace Greg.Requests
 {
+    /// <summary>
+    /// Request for getting a specific package version.
+    /// </summary>
     public class HeaderVersionDownload : PackageReferenceRequest
     {
         private string _versionId;

--- a/src/GregClient/Requests/HeaderVersionDownload.cs
+++ b/src/GregClient/Requests/HeaderVersionDownload.cs
@@ -1,0 +1,51 @@
+﻿using RestSharp;
+
+namespace Greg.Requests
+{
+    public class HeaderVersionDownload : PackageReferenceRequest
+    {
+        private string _versionId;
+
+        public HeaderVersionDownload(string id, string versionId)
+        {
+            this._type = PackageReferenceStyle.Id;
+            this._id = id;
+            this._versionId = versionId;
+        }
+
+        public HeaderVersionDownload(string engine, string name, string versionId)
+        {
+            this._type = PackageReferenceStyle.EngineAndName;
+            this._name = name;
+            this._engine = engine;
+            this._versionId = versionId;
+        }
+
+        public override string Path
+        {
+            get
+            {
+                if (this._type == PackageReferenceStyle.Id)
+                {
+                    return "package_version/" + this._id + "/" + this._versionId;
+                }
+                else
+                {
+                    return "package_version/" + this._engine + "/" + this._name + "/" + this._versionId;
+                }
+            }
+        }
+
+        public override Method HttpMethod
+        {
+            get
+            {
+                return Method.GET;
+            }
+        }
+
+        internal override void Build(ref RestRequest request)
+        {
+        }
+    }
+}

--- a/src/GregClientSandbox/Program.cs
+++ b/src/GregClientSandbox/Program.cs
@@ -7,6 +7,7 @@ using Greg.Responses;
 using Greg.Utility;
 using Greg.AuthProviders;
 using RestSharp;
+using RestSharp.Serializers;
 
 namespace GregClientSandbox
 {
@@ -152,12 +153,21 @@ namespace GregClientSandbox
             var hostsResponse = pmc.ExecuteAndDeserializeWithContent<List<String>>(hosts);
             Console.WriteLine(hostsResponse.content);
         }
+
+        private static void GetPackageVersionHeaderTest()
+        {
+            var req = new HeaderVersionDownload("dynamo", "get package version test", "0.1.1");
+            var res = pmc.ExecuteAndDeserializeWithContent<PackageVersion>(req);
+            var serializer = new JsonSerializer();
+            Console.WriteLine(serializer.Serialize(res.content));
+        }
         
         static void Main(string[] args)
         {
             //ListHostsTest();
             //DownloadPackageByIdTest();
             //DownloadAllPackagesTest();
+            //GetPackageVersionHeaderTest();
             GetWhitelistTest();
             Console.Read();
         }

--- a/src/GregClient_net45/GregClient_net45.csproj
+++ b/src/GregClient_net45/GregClient_net45.csproj
@@ -59,6 +59,9 @@
     <Compile Include="..\GregClient\AuthProviders\LoginState.cs">
       <Link>AuthProviders\LoginState.cs</Link>
     </Compile>
+    <Compile Include="..\GregClient\Converters\DependencyConverter.cs">
+      <Link>Converters\DependencyConverter.cs</Link>
+    </Compile>
     <Compile Include="..\GregClient\GregClient.cs">
       <Link>GregClient.cs</Link>
     </Compile>
@@ -85,6 +88,9 @@
     </Compile>
     <Compile Include="..\GregClient\Requests\HeaderDownload.cs">
       <Link>Requests\HeaderDownload.cs</Link>
+    </Compile>
+    <Compile Include="..\GregClient\Requests\HeaderVersionDownload.cs">
+      <Link>Requests\HeaderVersionDownload.cs</Link>
     </Compile>
     <Compile Include="..\GregClient\Requests\JSONRequest.cs">
       <Link>Requests\JSONRequest.cs</Link>


### PR DESCRIPTION
This adds a request type HeaderVersionDownload that supports either:
- package id, package version
- engine, package name, package version

The response is a PackageVersion, which will contain just the ids for
dependencies, but preserves the existing structure. This is achieved by
using custom JSON deserialization with DependencyConverter.