### PR TITLE
Exposing endpoint to get maintainers of a package in Greg

### DIFF
--- a/src/GregClient/GregClient.csproj
+++ b/src/GregClient/GregClient.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Requests\BanPackage.cs" />
     <Compile Include="Requests\Deprecate.cs" />
     <Compile Include="Requests\Downvote.cs" />
+    <Compile Include="Requests\GetMaintainers.cs" />
     <Compile Include="Requests\Hosts.cs" />
     <Compile Include="Requests\PackageManagerRequest.cs" />
     <Compile Include="Requests\PackageReferenceRequest.cs" />

--- a/src/GregClient/Properties/globalVersionInfo.cs
+++ b/src/GregClient/Properties/globalVersionInfo.cs
@@ -3,4 +3,4 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 
-[assembly: AssemblyVersion("1.2.*")]
+[assembly: AssemblyVersion("1.3.*")]

--- a/src/GregClient/Requests/GetMaintainers.cs
+++ b/src/GregClient/Requests/GetMaintainers.cs
@@ -2,6 +2,9 @@
 
 namespace Greg.Requests
 {
+    /// <summary>
+    /// Request for getting maintainers of a specific package.
+    /// </summary>
     public class GetMaintainers : PackageReferenceRequest
     {
 

--- a/src/GregClient/Requests/GetMaintainers.cs
+++ b/src/GregClient/Requests/GetMaintainers.cs
@@ -1,0 +1,32 @@
+﻿using RestSharp;
+
+namespace Greg.Requests
+{
+    public class GetMaintainers : PackageReferenceRequest
+    {
+
+        public GetMaintainers(string engine, string name)
+        {
+            this._name = name;
+            this._engine = engine;
+        }
+
+        public override string Path
+        {
+            get
+            {
+                return "package/" + this._engine + "/" + this._name + "/maintainers";
+            }
+        }
+
+        public override Method HttpMethod
+        {
+            get { return Method.GET; }
+        }
+
+        internal override void Build(ref RestRequest request)
+        {
+
+        }
+    }
+}

--- a/src/GregClientSandbox/Program.cs
+++ b/src/GregClientSandbox/Program.cs
@@ -106,6 +106,13 @@ namespace GregClientSandbox
             Console.WriteLine(pkgResponse.content);
         }
 
+        private static void DownloadDynamoPackageMaintainersByEngineAndNameTest()
+        {
+            var nv = new GetMaintainers("dynamo", "Third .NET Package");
+            var pkgResponse = pmc.ExecuteAndDeserializeWithContent<PackageHeader>(nv);
+            Console.WriteLine(pkgResponse.content);
+        }
+
         private static void SearchWithQueryTest()
         {
             var nv = new Search("*ython");

--- a/src/GregClient_net45/GregClient_net45.csproj
+++ b/src/GregClient_net45/GregClient_net45.csproj
@@ -80,6 +80,9 @@
     <Compile Include="..\GregClient\Requests\Downvote.cs">
       <Link>Requests\Downvote.cs</Link>
     </Compile>
+    <Compile Include="..\GregClient\Requests\GetMaintainers.cs">
+      <Link>Requests\GetMaintainers.cs</Link>
+    </Compile>
     <Compile Include="..\GregClient\Requests\HeaderCollectionDownload.cs">
       <Link>Requests\HeaderCollectionDownload.cs</Link>
     </Compile>


### PR DESCRIPTION
### Purpose

Exposing endpoint to get maintainers of a specific package provided its name and engine.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 
