### PR TITLE
DYN-2601

### DIFF
--- a/src/GregClient/Utility/FileUtilities.cs
+++ b/src/GregClient/Utility/FileUtilities.cs
@@ -79,11 +79,19 @@ namespace Greg.Utility
             return hashValue;
         }
 
+        /// <summary>
+        /// Gets the full path of the user temporary folder
+        /// </summary>
+        /// <returns>String with the full path of the user temporary folder</returns>
         public static string GetTempFolder()
         {
             return Path.GetDirectoryName(Path.GetTempPath());
         }
 
+        /// <summary>
+        /// Generates a full path under the temporary folder
+        /// </summary>
+        /// <returns>String with the full path</returns>
         public static string GetTempZipPath()
         {
             var tempFolder = GetTempFolder();
@@ -98,6 +106,10 @@ namespace Greg.Utility
             return tempZipPath;
         }
 
+        /// <summary>
+        /// Generates a full output path under the temporary folder
+        /// </summary>
+        /// <returns>String with the full path</returns>
         public static string GetTempZipOutputPath()
         {
             var tempFolder = GetTempFolder();

--- a/src/GregClient/Utility/FileUtilities.cs
+++ b/src/GregClient/Utility/FileUtilities.cs
@@ -89,39 +89,43 @@ namespace Greg.Utility
         }
 
         /// <summary>
-        /// Generates a full path under the temporary folder
+        /// Generates a full path under the temporary folder with the prefix 'gregPkg'
         /// </summary>
         /// <returns>String with the full path</returns>
         public static string GetTempZipPath()
         {
-            var tempFolder = GetTempFolder();
-            string tempZipPath = Path.Combine(tempFolder, String.Format("gregPkg{0}.zip", DateTime.Now.Millisecond.ToString());
-            int range = 1;
-
-            while (File.Exists(tempZipPath))
-            {
-                tempZipPath = Path.Combine(tempFolder, String.Format("gregPkg{0}{1}.zip", DateTime.Now.Millisecond.ToString(), range++));
-            }
+            string tempZipPath = GetZipPath("gregPkg"); 
 
             return tempZipPath;
         }
 
         /// <summary>
-        /// Generates a full output path under the temporary folder
+        /// Generates a full output path under the temporary folder with the prefix 'gregPkgOutput'
         /// </summary>
         /// <returns>String with the full path</returns>
         public static string GetTempZipOutputPath()
         {
-            var tempFolder = GetTempFolder();
-            string tempZipOutputPath = Path.Combine(tempFolder, String.Format("gregPkgOutput{0}.zip", DateTime.Now.Millisecond.ToString());
-            int range = 1;
-
-            while (File.Exists(tempZipOutputPath))
-            {
-                tempZipOutputPath = Path.Combine(tempFolder, String.Format("gregPkgOutput{0}{1}.zip", DateTime.Now.Millisecond.ToString(), range++));
-            }
+            string tempZipOutputPath = GetZipPath("gregPkgOutput");
 
             return tempZipOutputPath;
+        }
+
+        /// <summary>
+        /// Generates a full path under the temporary folder of a zip file with a format like this prefix[GUID].zip
+        /// </summary>
+        /// <param name="prefixFileName">Prefix of the file</param>
+        /// <returns>String with the full path</returns>
+        private static string GetZipPath(string prefixFileName)
+        {
+            var tempFolder = GetTempFolder();
+            string zipPath = Path.Combine(tempFolder, String.Format("{0}{1}.zip", prefixFileName, Guid.NewGuid().ToString()));
+
+            while (File.Exists(zipPath))
+            {
+                zipPath = Path.Combine(tempFolder, String.Format("{0}{1}.zip", prefixFileName, Guid.NewGuid().ToString()));
+            }
+
+            return zipPath;
         }
 
         /// <summary>

--- a/src/GregClient/Utility/FileUtilities.cs
+++ b/src/GregClient/Utility/FileUtilities.cs
@@ -87,13 +87,29 @@ namespace Greg.Utility
         public static string GetTempZipPath()
         {
             var tempFolder = GetTempFolder();
-            return Path.Combine(tempFolder, "gregPkg" + DateTime.Now.Millisecond.ToString() + ".zip");
+            string tempZipPath = Path.Combine(tempFolder, String.Format("gregPkg{0}.zip", DateTime.Now.Millisecond.ToString());
+            int range = 1;
+
+            while (File.Exists(tempZipPath))
+            {
+                tempZipPath = Path.Combine(tempFolder, String.Format("gregPkg{0}{1}.zip", DateTime.Now.Millisecond.ToString(), range++));
+            }
+
+            return tempZipPath;
         }
 
         public static string GetTempZipOutputPath()
         {
             var tempFolder = GetTempFolder();
-            return Path.Combine(tempFolder, "gregPkgOutput" + DateTime.Now.Millisecond.ToString());
+            string tempZipOutputPath = Path.Combine(tempFolder, String.Format("gregPkgOutput{0}.zip", DateTime.Now.Millisecond.ToString());
+            int range = 1;
+
+            while (File.Exists(tempZipOutputPath))
+            {
+                tempZipOutputPath = Path.Combine(tempFolder, String.Format("gregPkgOutput{0}{1}.zip", DateTime.Now.Millisecond.ToString(), range++));
+            }
+
+            return tempZipOutputPath;
         }
 
         /// <summary>

--- a/src/GregClient/Utility/FileUtilities.cs
+++ b/src/GregClient/Utility/FileUtilities.cs
@@ -119,12 +119,7 @@ namespace Greg.Utility
         {
             var tempFolder = GetTempFolder();
             string zipPath = Path.Combine(tempFolder, String.Format("{0}{1}.zip", prefixFileName, Guid.NewGuid().ToString()));
-
-            while (File.Exists(zipPath))
-            {
-                zipPath = Path.Combine(tempFolder, String.Format("{0}{1}.zip", prefixFileName, Guid.NewGuid().ToString()));
-            }
-
+            
             return zipPath;
         }
 


### PR DESCRIPTION
### Purpose

Changes to avoid IOException with File Already exists message when compressing a file

https://jira.autodesk.com/browse/DYN-2601

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@mjkkirschner 

@QilongTang .

