### PR TITLE
update restsharp to latest stable 106.12.0

### DIFF
--- a/nuspec/GregClient.nuspec
+++ b/nuspec/GregClient.nuspec
@@ -9,23 +9,23 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The Dynamo Package Manager .Net Client.</description>
     <releaseNotes>The Dynamo Package Manager .Net Client.</releaseNotes>
-    <copyright>Copyright 2020</copyright>
+    <copyright>Copyright 2021</copyright>
     <license type="expression">MIT</license>
     <icon>content\images\logo.png</icon>
     <tags>dynamo package greg</tags>
     <dependencies>
       <group>
-        <dependency id="RestSharp" version="105.2.3" />
+        <dependency id="RestSharp" version="106.12.0" />
         <dependency id="Newtonsoft.Json" version="8.0.3" />
       </group>
-      <group targetFramework=".NETFramework4.5">
+      <group targetFramework=".NETFramework4.5.2">
       </group>
       <group targetFramework=".NETFramework4.8">
       </group>
     </dependencies>	
   </metadata>
   <files>
-    <file src="net45\Greg.dll" target="lib\net45" />
+    <file src="net452\Greg.dll" target="lib\net452" />
     <file src="Greg.dll" target="lib\net48" />
     <file src="..\..\nuspec\images\logo_square_32x32.png" target="content\images\logo.png" />
   </files>

--- a/nuspec/GregClient.nuspec
+++ b/nuspec/GregClient.nuspec
@@ -14,13 +14,13 @@
     <icon>content\images\logo.png</icon>
     <tags>dynamo package greg</tags>
     <dependencies>
-      <group>
-        <dependency id="RestSharp" version="106.12.0" />
+      <group targetFramework=".NETFramework4.5.2">
+ <dependency id="RestSharp" version="106.12.0" />
         <dependency id="Newtonsoft.Json" version="8.0.3" />
       </group>
-      <group targetFramework=".NETFramework4.5.2">
-      </group>
       <group targetFramework=".NETFramework4.8">
+ <dependency id="RestSharp" version="106.12.0" />
+        <dependency id="Newtonsoft.Json" version="8.0.3" />
       </group>
     </dependencies>	
   </metadata>

--- a/src/GregClient.sln
+++ b/src/GregClient.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2036
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31613.86
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GregClient", "GregClient\GregClient.csproj", "{644207B4-7E7F-474A-952E-3453960D8A01}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -10,7 +10,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GregClient", "GregClient\Gr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GregClientSandbox", "GregClientSandbox\GregClientSandbox.csproj", "{12F6037C-A559-408E-AD10-4FBF05285AC3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GregClient_net45", "GregClient_net45\GregClient_net45.csproj", "{B45317C9-5509-47D6-832D-24E20BF640A0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GregClient_net452", "GregClient_net45\GregClient_net452.csproj", "{B45317C9-5509-47D6-832D-24E20BF640A0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/GregClient.sln.DotSettings
+++ b/src/GregClient.sln.DotSettings
@@ -1,3 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String>
-	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String></wpf:ResourceDictionary>

--- a/src/GregClient/GregClient.cs
+++ b/src/GregClient/GregClient.cs
@@ -1,8 +1,8 @@
-﻿using System.Net;
-using Greg.Requests;
+﻿using Greg.Requests;
 using Greg.Responses;
 using RestSharp;
 using System;
+using System.Net;
 
 namespace Greg
 {

--- a/src/GregClient/GregClient.csproj
+++ b/src/GregClient/GregClient.csproj
@@ -37,14 +37,15 @@
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.12.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.12.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AuthProviders\BasicProvider.cs" />

--- a/src/GregClient/Properties/globalVersionInfo.cs
+++ b/src/GregClient/Properties/globalVersionInfo.cs
@@ -3,4 +3,4 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 
-[assembly: AssemblyVersion("2.0.*")]
+[assembly: AssemblyVersion("2.1.*")]

--- a/src/GregClient/Requests/RequestBody.cs
+++ b/src/GregClient/Requests/RequestBody.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using RestSharp.Serializers;
+﻿using RestSharp.Serialization.Json;
 
 namespace Greg.Requests
 {

--- a/src/GregClient/packages.config
+++ b/src/GregClient/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net48" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
+  <package id="RestSharp" version="106.12.0" targetFramework="net48" />
 </packages>

--- a/src/GregClientSandbox/GregClientSandbox.csproj
+++ b/src/GregClientSandbox/GregClientSandbox.csproj
@@ -37,12 +37,13 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.12.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.12.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />

--- a/src/GregClientSandbox/Program.cs
+++ b/src/GregClientSandbox/Program.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Greg;
 using Greg.Requests;
 using Greg.Responses;
 using Greg.Utility;
 using Greg.AuthProviders;
 using RestSharp;
-using RestSharp.Serializers;
+using RestSharp.Serialization.Json;
 
 namespace GregClientSandbox
 {

--- a/src/GregClientSandbox/packages.config
+++ b/src/GregClientSandbox/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.2.3" targetFramework="net48" />
+  <package id="RestSharp" version="106.12.0" targetFramework="net48" />
 </packages>

--- a/src/GregClient_net45/GregClient_net452.csproj
+++ b/src/GregClient_net45/GregClient_net452.csproj
@@ -9,15 +9,16 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Greg</RootNamespace>
     <AssemblyName>Greg</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>false</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\Debug\net45</OutputPath>
+    <OutputPath>..\..\bin\Debug\net452\</OutputPath>
     <DefineConstants>TRACE;DEBUG;LT_NET47</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\Release\net45</OutputPath>
+    <OutputPath>..\..\bin\Release\net452\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -35,7 +36,7 @@
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
+      <HintPath>..\packages\RestSharp.106.12.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />


### PR DESCRIPTION
### Purpose

This PR updates restsharp in this repo to 106.12.0 - I will send followups to GregOAuth and Dynamo at the minimum - likely also DynamoRevit.

* updates nuget package refs
* updates target framework of net45 target to net452 - as RestSharp no longer supports net45. (Revit 2016)
* updates nuspec with better dependency groups based on .net target version
* update copyright year.
* fix some changed namespaces in restsharp.

### TODO
- [ ] send followup prs 
- [x] test upload in DynamoRevit with auth.
- [x] test in dynamo sandbox for download.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
