### PR TITLE
Add new code path and oauth2 interface to package manager client

### DIFF
--- a/src/GregClient/AuthProviders/IAuthProvider.cs
+++ b/src/GregClient/AuthProviders/IAuthProvider.cs
@@ -11,10 +11,29 @@ namespace Greg
 
         LoginState LoginState { get; }
         string Username { get; }
-
+        /// <summary>
+        /// This method should sign the request and params as OAuth1.
+        /// OAuth parameters should be added to the query string.
+        /// </summary>
+        /// <param name="m"></param>
+        /// <param name="client"></param>
         void SignRequest(ref RestRequest m, RestClient client);
 
         void Logout();
         bool Login();
+    }
+
+    /// <summary>
+    /// Implement this interface to use OAuth2 for authentication with Dynamo Package Manager.
+    /// </summary>
+    public interface IOAuth2AuthProvider : IAuthProvider
+    {
+        /// <summary>
+        /// This method should add the JWT access token to the Authorization header.
+        /// Package manager expects a header in the form: Authorization: Bearer [accesstoken]
+        /// </summary>
+        /// <param name="m"></param>
+        /// <param name="client"></param>
+        new void SignRequest(ref RestRequest m, RestClient client);
     }
 }

--- a/src/GregClient/GregClient.cs
+++ b/src/GregClient/GregClient.cs
@@ -44,19 +44,29 @@ namespace Greg
 
             if (m.RequiresAuthorization)
             {
-                // Issue: auth api was adding body params to the query string.
-                // Details: https://jira.autodesk.com/browse/DYN-1795
-                // Build a subset of the original request, with only specific parameters that we need to authenticate.
-                var reqToSign = new RestRequest(req.Resource, req.Method);
-                var authParams = m.GetParamsToSign(ref req);
-                foreach (var par in authParams)
+                //oauth2 - we don't need to sign/encode any parameters.
+                //Also don't need to create a temp request to avoid adsso putting header/body params
+                //in the query string. Just use original request, and inject access token.
+                if (AuthProvider is IOAuth2AuthProvider)
                 {
-                    reqToSign.AddParameter(par);
+                    AuthProvider.SignRequest(ref req, _client);
                 }
-
-                // All reqToSign.Parameters will be added in the reqToSign.Resource.
-                AuthProvider.SignRequest(ref reqToSign, _client);
-                req.Resource = reqToSign.Resource;
+                //oauth1
+                else
+                { // Issue: auth api was adding body params to the query string.
+                  // Details: https://jira.autodesk.com/browse/DYN-1795
+                  // Build a subset of the original request, with only specific parameters that we need to authenticate.
+                  // This means headers added in SignRequest will not exist on the request made to DPM. 
+                    var reqToSign = new RestRequest(req.Resource, req.Method);
+                    var authParams = m.GetParamsToSign(ref req);
+                    foreach (var par in authParams)
+                    {
+                        reqToSign.AddParameter(par);
+                    }
+                    // All reqToSign.Parameters will be added in the reqToSign.Resource.
+                    AuthProvider.SignRequest(ref reqToSign, _client);
+                    req.Resource = reqToSign.Resource;
+                }
             }
 
             try


### PR DESCRIPTION
### Purpose

This PR adds a very simple interface for oauth2 to package manager client - in fact it's exactly the same as the existing interface, but the new type let's us very easily ascertain which operations should be done to the request during signing. In particular there are some workarounds in place for dealing with how adsso signing was modifying the resulting http resource string that we can avoid if we know the auth provider intends to make oauth2 requests.

work for clients is extremely minimal as can be seen in this PR to GregOAuth for the Revit implementation.
https://git.autodesk.com/Dynamo/GRegOAuth/pull/23

Also updated the interface comments a bit.


### TODO:
- [x] once this is merged and nuget updated, this PR must point to new greg nuget version: https://git.autodesk.com/Dynamo/GRegOAuth/pull/23
- [ ] Dynamo must consume latest greg nuget in new PR
- [ ] DynamoRevit must consume GregOAuth nuget and Greg Nuget in new PR. https://github.com/DynamoDS/DynamoRevit/pull/2757
- [x] Manual testing, upload package, deprecate, undeprecate.

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

