### PR TITLE
Add Copyright Holder and Year fields 

### DIFF
--- a/nuspec/ManualBuildPackage.ps1
+++ b/nuspec/ManualBuildPackage.ps1
@@ -12,11 +12,13 @@ param (
     $NugetPath,
     [Parameter(Mandatory)]
     [string]
-    $OutputPackage
+    $OutputPackage,
+    [string]
+    $Configuration = 'Debug'
 )
 $ErrorActionPreference = "Stop"
 
-$assemblyPath = "$RepositoryPath\bin\Debug"
+$assemblyPath = "$RepositoryPath\bin\$Configuration"
 $nuspecPath = "$RepositoryPath\nuspec"
 
 $dllVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$assemblyPath\Greg.dll").FileVersion

--- a/src/GregClient/Requests/PackageUploadRequestBody.cs
+++ b/src/GregClient/Requests/PackageUploadRequestBody.cs
@@ -23,7 +23,8 @@ namespace Greg.Requests
             string contents, string engine, string engineVersion,
             string metadata, string group, IEnumerable<PackageDependency> dependencies,
             string siteUrl, string repositoryUrl, bool containsBinaries, 
-            IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies):
+            IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies,
+            string copyright_holder, string copyright_year) :
 
             this(name,version,description,
                 keywords,license,
@@ -33,6 +34,8 @@ namespace Greg.Requests
                 nodeLibraryNames)
         {
             this.host_dependencies = hostDependencies;
+            this.copyright_holder = copyright_holder;
+            this.copyright_year = copyright_year;
         }
 
         [Obsolete("This constructor will be removed in a future release of packageManagerClient.")]

--- a/src/GregClient/Requests/PackageVersionUploadRequestBody.cs
+++ b/src/GregClient/Requests/PackageVersionUploadRequestBody.cs
@@ -28,13 +28,16 @@ namespace Greg.Requests
         /// <param name="repositoryUrl"></param>
         /// <param name="containsBinaries">boolean flag indicating if the package contains binaries</param>
         /// <param name="nodeLibraryNames"></param>
-        /// <param name="hostDependencies"> external programs this package depends on.</param>
+        /// <param name="hostDependencies"> external programs this package depends on.</param
+        /// <param name="copyright_holder">Copyright Holder's name</param>
+        /// <param name="copyright_year">Year the copyright was put into effect.</param>
         public PackageVersionUploadRequestBody(string name, string version, string description,
           IEnumerable<string> keywords,
           string contents, string engine, string engineVersion,
           string metadata, string group, IEnumerable<PackageDependency> dependencies,
           string siteUrl, string repositoryUrl, bool containsBinaries,
-          IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies) :
+          IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies,
+          string copyright_holder, string copyright_year) :
 
           this(name, version, description,
               keywords,
@@ -44,6 +47,8 @@ namespace Greg.Requests
               nodeLibraryNames)
         {
             this.host_dependencies = hostDependencies;
+            this.copyright_holder = copyright_holder;
+            this.copyright_year = copyright_year;
         }
 
         /// <summary>
@@ -103,5 +108,7 @@ namespace Greg.Requests
         public string repository_url { get; set; }
         public bool contains_binaries { get; set; }
         public IEnumerable<string> node_libraries { get; set; }
+        public string copyright_holder { get; set; }
+        public string copyright_year { get; set; }
     }
 }

--- a/src/GregClientSandbox/Program.cs
+++ b/src/GregClientSandbox/Program.cs
@@ -40,7 +40,7 @@ namespace GregClientSandbox
             var keywords = new List<string>() {"neat", "ok"};
             var nv = new PackageVersionUploadRequestBody("Third .NET Package", "2.1.0", "", keywords, "contents", "dynamo", "0.1.0", "metadata", "group",
                             new List<PackageDependency>() { new PackageDependency("peter", "0.1.0"), new PackageDependency("stephen", "0.1.0") }, "", "", 
-                            false, new List<String>(), new List<String>());
+                            false, new List<String>(), new List<String>(), "Dynamo Team", "2021");
 
             var files = new List<string>() {"../test/pedro.dyf", "../test/RootNode.dyf"};
             var request = new PackageVersionUpload(nv, files);
@@ -52,7 +52,7 @@ namespace GregClientSandbox
             var keywords = new List<string>() { "Civil" };
             var nv = new PackageVersionUploadRequestBody("Third .NET Package", "2.1.0", "", keywords, "contents", "dynamo", "0.1.0", "metadata", "group",
                             new List<PackageDependency>() { new PackageDependency("Ram", "0.1.0"), new PackageDependency("Ian", "0.1.0") }, "", "",
-                            false, new List<String>(), new List<String>() { "Civil3D" });
+                            false, new List<String>(), new List<String>() { "Civil3D" }, "Dynamo Team", "2021");
 
             var files = new List<string>() { "../test/pedro.dyf", "../test/RootNode.dyf" };
             var request = new PackageVersionUpload(nv, files);
@@ -63,7 +63,7 @@ namespace GregClientSandbox
         {
             var keywords = new List<string>() { "neat", "ok" };
             var nv = new PackageVersionUploadRequestBody("Third .NET Package", "2.1.0", "", keywords, "contents", "dynamo", "0.1.0", "metadata", "group", 
-                new List<PackageDependency>() { new PackageDependency("peter", "0.1.0"), new PackageDependency("stephen", "0.1.0") }, "", "", false, new List<String>(), new List<String>());
+                new List<PackageDependency>() { new PackageDependency("peter", "0.1.0"), new PackageDependency("stephen", "0.1.0") }, "", "", false, new List<String>(), new List<String>(), "", "");
 
             var files = new List<string>() {"../../../../test/pedro.dyf", "../../../../test/RootNode.dyf"};
 


### PR DESCRIPTION
### Purpose

Added copyright fields to the metadata to be serialized (Will not be uploaded yet)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 
