### PR TITLE
Add Copyright properties to the response

### DIFF
--- a/src/GregClient/Responses/Responses.cs
+++ b/src/GregClient/Responses/Responses.cs
@@ -126,6 +126,10 @@ namespace Greg.Responses
         public string name { get; set; }
 
         public string id { get; set; }
+
+        public string copyright_holder { get; set; }
+
+        public string copyright_year { get; set; }
     }
 
     public class User


### PR DESCRIPTION
### Purpose

Add the Copyright properties to the Package version response in order to be consumed in the UI like Dynamo

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@QilongTang

### FYIs
@RobertGlobant20 @filipeotero
