### PR TITLE
Add net6.0 as a target framework

### DIFF
--- a/src/AssemblyInfoGenerator/AssemblyInfo.cs
+++ b/src/AssemblyInfoGenerator/AssemblyInfo.cs
@@ -36,7 +36,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.5.0.5016")]
+[assembly: AssemblyVersion("2.5.0.5025")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -55,4 +55,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.5.0.5016")]
+[assembly: AssemblyFileVersion("2.5.0.5025")]

--- a/src/AssemblyInfoGenerator/AssemblyInfo.cs
+++ b/src/AssemblyInfoGenerator/AssemblyInfo.cs
@@ -36,7 +36,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.5.0.5025")]
+[assembly: AssemblyVersion("2.5.0.5065")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -55,4 +55,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.5.0.5025")]
+[assembly: AssemblyFileVersion("2.5.0.5065")]

--- a/src/AssemblyInfoGenerator/AssemblyInfo.cs
+++ b/src/AssemblyInfoGenerator/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Greg")]
 [assembly: AssemblyTitle("Greg")]
 [assembly: AssemblyDescription("The Dynamo Package Manager .NET client.")]
-[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2022")]
+[assembly: AssemblyCopyright("Copyright � Autodesk, Inc 2022")]
 [assembly: AssemblyTrademark("")]
 
 // Make it easy to distinguish Debug and Release (i.e. Retail) builds;
@@ -36,7 +36,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.4.0.4747")]
+[assembly: AssemblyVersion("2.4.0.5007")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -55,4 +55,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.4.0.4747")]
+[assembly: AssemblyFileVersion("2.4.0.5007")]

--- a/src/AssemblyInfoGenerator/AssemblyInfo.cs
+++ b/src/AssemblyInfoGenerator/AssemblyInfo.cs
@@ -36,7 +36,7 @@ using System.Runtime.InteropServices;
 // to distinguish one build from another. AssemblyFileVersion is specified
 // in AssemblyVersionInfo.cs so that it can be easily incremented by the
 // automated build process.
-[assembly: AssemblyVersion("2.4.0.5007")]
+[assembly: AssemblyVersion("2.5.0.5016")]
 
 
 // By default, the "Product version" shown in the file properties window is
@@ -55,4 +55,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("2.4.0.5007")]
+[assembly: AssemblyFileVersion("2.5.0.5016")]

--- a/src/AssemblyInfoGenerator/AssemblyInfo.tt
+++ b/src/AssemblyInfoGenerator/AssemblyInfo.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ template debug="false" hostspecific="false" language="C#" #>
 using System;
 using System.Reflection;
 using System.Resources;
@@ -59,7 +59,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("<#= this.MajorVersion #>.<#= this.MinorVersion #>.<#= this.BuildNumber #>.<#= this.RevisionNumber #>")]
 <#+
 int MajorVersion = 2;
-int MinorVersion = 4;
+int MinorVersion = 5;
 int BuildNumber = 0;
 // The datetime baseline we choose using this algorithm will affect build number and all nuget packages uploaded
 // Please only change when major or minor version got incremented

--- a/src/GregClient/GregClient.csproj
+++ b/src/GregClient/GregClient.csproj
@@ -49,7 +49,7 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup Label="Common package dependencies">
     <PackageReference Include="RestSharp" Version="106.12.0" />

--- a/src/GregClient/GregClient.csproj
+++ b/src/GregClient/GregClient.csproj
@@ -42,17 +42,14 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'net48'">
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-  </ItemGroup>
   <ItemGroup Label="Common package dependencies">
     <PackageReference Include="RestSharp" Version="106.12.0" />
+	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\CHANGELOG.md">

--- a/src/GregClient/GregClient.csproj
+++ b/src/GregClient/GregClient.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Greg</RootNamespace>
     <AssemblyName>Greg</AssemblyName>
-    <TargetFrameworks>net452;net48;net5.0</TargetFrameworks>
+    <TargetFrameworks>net452;net48;net5.0;net6.0</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
 	  <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -48,7 +48,7 @@
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Label="Common package dependencies">


### PR DESCRIPTION
### Purpose

Add the dotnet 6.0 as a new target framework for the Greg Client nuget package

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers
@mjkkirschner 
@jasonstratton 

### FYIs

