### PR TITLE
Fix output path for black duck scans

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -36,7 +36,7 @@ soc2:
     repository: env.HARMONY_REPO
     third_party_lib_paths:
       - "third_party"
-      - "bin/release"
+      - "bin\\release"
 
 deployment:
     -


### PR DESCRIPTION
### Purpose

Black Duck scans have been failing due to the slash direction, fixing to make the scans explore the build directory as well.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 
