### PR TITLE
Temporary switch to msbuild to enable text templating

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -43,7 +43,7 @@ build:
     scripts:
       - "pwsh.exe -ExecutionPolicy ByPass -File .\\cicdscripts\\DownloadCICDResources.ps1"
       - "pwsh.exe -ExecutionPolicy ByPass -File .\\%COMMON_TOOLS_DIR%\\scripts\\SetupHost.ps1"
-      - "dotnet build src/gregClient.sln --configuration Release"
+      - "msbuild src/gregClient.sln --configuration Release"
 ci_test:
   tests:
     -

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -59,7 +59,7 @@ soc2:
   harmony:
     hidden_email_list: dynamo_ws_access
     third_party_lib_paths:
-      - bin\\Release\\net8.0\\
+      - bin\Release\net8.0\
 
 deployment:
   

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -14,7 +14,6 @@ env:
   - SONARSCANTOOL : "SonarScannerMsbuild\\dotnet-framework-sonarscanner\\tools\\SonarScanner.MSBuild.exe"
   - NUGET_SOURCES : "nuget.org"
   - NUGET_CONFIG : "Config\\nuget.config"
-  - RELEASE_BRANCHES: "master"
   
 check_changelog_updated_on_pr: false
 pipeline_os: "Windows"


### PR DESCRIPTION
### Purpose

Switch to msbuild as dotnet build skips text templating, causing the revision number of the final package to be unchanged.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
