### PR TITLE
DYN-7471 Add compatibility matrix deserialization

### DIFF
--- a/src/GregClient/Requests/PackageUploadRequestBody.cs
+++ b/src/GregClient/Requests/PackageUploadRequestBody.cs
@@ -16,12 +16,13 @@ namespace Greg.Requests
         string metadata, string group, IEnumerable<PackageDependency> dependencies,
         string siteUrl, string repositoryUrl, bool containsBinaries,
         IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies,
-        string copyright_holder, string copyright_year, string releaseNotesUrl)
+        string copyright_holder, string copyright_year, string releaseNotesUrl, IEnumerable<PackageCompatibility> compatibilityMatrix)
         {
             this.host_dependencies = hostDependencies;
             this.copyright_holder = copyright_holder;
             this.copyright_year = copyright_year;
             this.release_notes_url = releaseNotesUrl;
+            this.compatibility_matrix = compatibilityMatrix;
 
             this.name = name;
             this.version = version;

--- a/src/GregClient/Requests/PackageVersionUpload.cs
+++ b/src/GregClient/Requests/PackageVersionUpload.cs
@@ -79,4 +79,18 @@ namespace Greg.Requests
         public string name { get; set; }
         public string version { get; set; }
     }
+    public class PackageCompatibility
+    {
+        public PackageCompatibility(string name, List<string> versions, string min, string max)
+        {
+            this.name = name;
+            this.versions = versions;
+            this.min = min;
+            this.max = max;
+        }
+        public string name { get; set; }
+        public List<string> versions { get; set; }
+        public string min { get; set; }
+        public string max { get; set; }
+    }
 }

--- a/src/GregClient/Requests/PackageVersionUploadRequestBody.cs
+++ b/src/GregClient/Requests/PackageVersionUploadRequestBody.cs
@@ -38,7 +38,7 @@ namespace Greg.Requests
           string metadata, string group, IEnumerable<PackageDependency> dependencies,
           string siteUrl, string repositoryUrl, bool containsBinaries,
           IEnumerable<string> nodeLibraryNames, IEnumerable<string> hostDependencies,
-          string copyright_holder, string copyright_year, string compatibility_matrix, string releaseNotesUrl)
+          string copyright_holder, string copyright_year, IEnumerable<PackageCompatibility> compatibilityMatrix, string releaseNotesUrl)
 
         {
             this.host_dependencies = hostDependencies;
@@ -60,6 +60,7 @@ namespace Greg.Requests
             this.node_libraries = nodeLibraryNames;
             this.compatibility_matrix = compatibility_matrix;
             this.release_notes_url = releaseNotesUrl;
+            this.compatibility_matrix = compatibilityMatrix;
         }
 
         /// <summary>
@@ -132,7 +133,7 @@ namespace Greg.Requests
         public IEnumerable<string> node_libraries { get; set; }
         public string copyright_holder { get; set; }
         public string copyright_year { get; set; }
-        public string compatibility_matrix { get; set; }
+        public IEnumerable<PackageCompatibility> compatibility_matrix { get; set; }
         public string release_notes_url { get; set; }
     }
 }

--- a/src/GregClient/Responses/Responses.cs
+++ b/src/GregClient/Responses/Responses.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using RestSharp;
 using Greg.Converters;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Greg.Responses
 {
@@ -78,6 +77,13 @@ namespace Greg.Responses
 
         public string _id { get; set; }
     }
+    public class Compatibility
+    {
+        public string name { get; set; }
+        public List<string> versions { get; set; }
+        public string min { get; set; }
+        public string max { get; set; }
+    }
 
     public class PackageVersion
     {
@@ -125,6 +131,7 @@ namespace Greg.Responses
 
         public string size { get; set; }
         public string release_notes_url { get; set; }
+        public List<Compatibility> compatibility_matrix { get; set; }
     }
 
     public class User

--- a/src/GregClientTests/GregClientTests.cs
+++ b/src/GregClientTests/GregClientTests.cs
@@ -56,11 +56,11 @@ namespace GregClientTests
             var keywords = new List<string>() { "neat", "ok" };
             var nv = new PackageVersionUploadRequestBody("Third .NET Package", "2.1.0", "", keywords, "contents", "dynamo", "0.1.0", "metadata", "group",
                             new List<PackageDependency>() { new PackageDependency("peter", "0.1.0"), new PackageDependency("stephen", "0.1.0") }, "", "",
-                            false, new List<String>(), new List<String>(), "Dynamo Team", "2021","","");
+                            false, new List<String>(), new List<String>(), "Dynamo Team", "2021",null,"");
 
             var files = new List<string>() { "../test/pedro.dyf", "../test/RootNode.dyf" };
             var request = new PackageVersionUpload(nv, files);
-            Assert.That(request.RequestBody.AsJson().Equals("{\"file_hash\":null,\"name\":\"Third .NET Package\",\"version\":\"2.1.0\",\"description\":\"\",\"group\":\"group\",\"keywords\":[\"neat\",\"ok\"],\"dependencies\":[{\"name\":\"peter\",\"version\":\"0.1.0\"},{\"name\":\"stephen\",\"version\":\"0.1.0\"}],\"host_dependencies\":[],\"contents\":\"contents\",\"engine_version\":\"0.1.0\",\"engine\":\"dynamo\",\"engine_metadata\":\"metadata\",\"site_url\":\"\",\"repository_url\":\"\",\"contains_binaries\":false,\"node_libraries\":[],\"copyright_holder\":\"Dynamo Team\",\"copyright_year\":\"2021\",\"compatibility_matrix\":\"\",\"release_notes_url\":\"\"}"));
+            Assert.That(request.RequestBody.AsJson().Equals("{\"file_hash\":null,\"name\":\"Third .NET Package\",\"version\":\"2.1.0\",\"description\":\"\",\"group\":\"group\",\"keywords\":[\"neat\",\"ok\"],\"dependencies\":[{\"name\":\"peter\",\"version\":\"0.1.0\"},{\"name\":\"stephen\",\"version\":\"0.1.0\"}],\"host_dependencies\":[],\"contents\":\"contents\",\"engine_version\":\"0.1.0\",\"engine\":\"dynamo\",\"engine_metadata\":\"metadata\",\"site_url\":\"\",\"repository_url\":\"\",\"contains_binaries\":false,\"node_libraries\":[],\"copyright_holder\":\"Dynamo Team\",\"copyright_year\":\"2021\",\"compatibility_matrix\":null,\"release_notes_url\":\"\"}"));
             Console.WriteLine(request.RequestBody.AsJson());
         }
         
@@ -70,11 +70,11 @@ namespace GregClientTests
             var keywords = new List<string>() { "Civil" };
             var nv = new PackageVersionUploadRequestBody("Third .NET Package", "2.1.0", "", keywords, "contents", "dynamo", "0.1.0", "metadata", "group",
                             new List<PackageDependency>() { new PackageDependency("Ram", "0.1.0"), new PackageDependency("Ian", "0.1.0") }, "", "",
-                            false, new List<String>(), new List<String>() { "Civil3D" }, "Dynamo Team", "2021", "", "");
+                            false, new List<String>(), new List<String>() { "Civil3D" }, "Dynamo Team", "2021", null, "");
 
             var files = new List<string>() { "../test/pedro.dyf", "../test/RootNode.dyf" };
             var request = new PackageVersionUpload(nv, files);
-            Assert.That(request.RequestBody.AsJson().Equals("{\"file_hash\":null,\"name\":\"Third .NET Package\",\"version\":\"2.1.0\",\"description\":\"\",\"group\":\"group\",\"keywords\":[\"Civil\"],\"dependencies\":[{\"name\":\"Ram\",\"version\":\"0.1.0\"},{\"name\":\"Ian\",\"version\":\"0.1.0\"}],\"host_dependencies\":[\"Civil3D\"],\"contents\":\"contents\",\"engine_version\":\"0.1.0\",\"engine\":\"dynamo\",\"engine_metadata\":\"metadata\",\"site_url\":\"\",\"repository_url\":\"\",\"contains_binaries\":false,\"node_libraries\":[],\"copyright_holder\":\"Dynamo Team\",\"copyright_year\":\"2021\",\"compatibility_matrix\":\"\",\"release_notes_url\":\"\"}"));
+            Assert.That(request.RequestBody.AsJson().Equals("{\"file_hash\":null,\"name\":\"Third .NET Package\",\"version\":\"2.1.0\",\"description\":\"\",\"group\":\"group\",\"keywords\":[\"Civil\"],\"dependencies\":[{\"name\":\"Ram\",\"version\":\"0.1.0\"},{\"name\":\"Ian\",\"version\":\"0.1.0\"}],\"host_dependencies\":[\"Civil3D\"],\"contents\":\"contents\",\"engine_version\":\"0.1.0\",\"engine\":\"dynamo\",\"engine_metadata\":\"metadata\",\"site_url\":\"\",\"repository_url\":\"\",\"contains_binaries\":false,\"node_libraries\":[],\"copyright_holder\":\"Dynamo Team\",\"copyright_year\":\"2021\",\"compatibility_matrix\":null,\"release_notes_url\":\"\"}"));
             Console.WriteLine(request.RequestBody.AsJson());
         }
         
@@ -83,7 +83,7 @@ namespace GregClientTests
         {
             var keywords = new List<string>() { "neat", "ok" };
             var nv = new PackageVersionUploadRequestBody("Third .NET Package", "2.1.0", "", keywords, "contents", "dynamo", "0.1.0", "metadata", "group",
-                new List<PackageDependency>() { new PackageDependency("peter", "0.1.0"), new PackageDependency("stephen", "0.1.0") }, "", "", false, new List<String>(), new List<String>(), "", "", "", "");
+                new List<PackageDependency>() { new PackageDependency("peter", "0.1.0"), new PackageDependency("stephen", "0.1.0") }, "", "", false, new List<String>(), new List<String>(), "", "", null, "");
 
             var files = new List<string>() {Assembly.GetExecutingAssembly().Location };
 
@@ -160,6 +160,37 @@ namespace GregClientTests
             Console.WriteLine(JsonSerializer.Serialize(hostsResponse.content));
             Assert.That(hostsResponse.content.Count, Is.EqualTo(5));
         }
-        
+
+        [Test]
+
+        public void TestCompatibilityDeserializationTest()
+        {
+            var mockResponse= @"[
+                {
+                    ""name"" : ""dynamo"",
+                    ""versions"" : [""2.17"",""2.18""],
+                    ""min"" : ""2.17"",
+                    ""max"" : ""3.0""
+                },
+                {
+                    ""name"" : ""revit"",
+                    ""versions"" : [""2024"",""2025""],
+                    ""min"" : ""2025""
+                },
+                {
+                    ""name"" : ""civil3d"",
+                    ""min"" : ""2025"",
+                    ""max"" : ""2024""
+                },
+                {
+                    ""name"" : "".net"",
+                    ""max"" : ""net8""
+                }
+            ]";
+            var cm = JsonSerializer.Deserialize<List<PackageCompatibility>>(mockResponse);
+            Assert.That(cm, !Is.Null);
+            Assert.That(cm, Has.Count.EqualTo(4));
+        }
+
     }
 }


### PR DESCRIPTION
### Purpose

Adding compatibility matrix to PMClient with deserialization so Dynamo gets a collection of different compatibility info instead of a string.

The PR introduces changes to the compatibility schema:
The changes are not huge, it is proposed to change the json structure from a dictionary to an array of objects, reason behind this is since we need to deserialize this json property into a dictionary, we will also need to convert it into an observable collection when consuming it in Dynamo, an Observable Dictionary is more complex and will probably require creating this Observable Dictionary class from scratch, I feel using an already existing Observable Collection makes more sense.
The schema [wiki](https://wiki.autodesk.com/display/GEN/Dynamo+Package+Compatibility+Schema) has been updated with the new proposal, also added a test for deserialization.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
