### PR TITLE
DYN-7571 Add Compatibility Map route as an API

### DIFF
--- a/src/GregClient/Requests/GetCompatibilityMap.cs
+++ b/src/GregClient/Requests/GetCompatibilityMap.cs
@@ -8,6 +8,10 @@ using RestSharp;
 
 namespace Greg.Requests
 {
+    /// <summary>
+    /// Returns the compatibility information with a fixed map of host applications
+    /// and it's respective supported Dynamo version
+    /// </summary>
     public class GetCompatibilityMap : Request
     {
         public GetCompatibilityMap()

--- a/src/GregClient/Requests/GetCompatibilityMap.cs
+++ b/src/GregClient/Requests/GetCompatibilityMap.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using RestSharp;
+
+namespace Greg.Requests
+{
+    public class GetCompatibilityMap : Request
+    {
+        public GetCompatibilityMap()
+        {
+        }
+
+        public override string Path
+        {
+            get { return "host_map"; }
+        }
+
+        public override HttpMethod HttpMethod
+        {
+            get { return HttpMethod.Get; }
+        }
+
+        internal override void Build(ref RestRequest request)
+        {
+        }
+    }
+}

--- a/src/GregClientTests/GregClientTests.cs
+++ b/src/GregClientTests/GregClientTests.cs
@@ -2,6 +2,7 @@ using Greg;
 using Greg.Requests;
 using Greg.Responses;
 using Greg.Utility;
+using Newtonsoft.Json.Linq;
 using RestSharp;
 using System.Reflection;
 using System.Text.Json;
@@ -159,6 +160,19 @@ namespace GregClientTests
             var hostsResponse = pmc.ExecuteAndDeserializeWithContent<List<String>>(hosts);
             Console.WriteLine(JsonSerializer.Serialize(hostsResponse.content));
             Assert.That(hostsResponse.content.Count, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void ListCompatibilityMapTest()
+        {
+            GregClient pmc = new GregClient(null, "http://dynamopackages.com/");
+            var comMap = new GetCompatibilityMap();
+            var comMapResponse = pmc.ExecuteAndDeserializeWithContent<object>(comMap);
+            Assert.That(comMapResponse.content != null, Is.EqualTo(true));
+            var content = JsonSerializer.Serialize(comMapResponse.content);
+            Console.WriteLine(content);
+            var jsonResp = JArray.Parse(content);
+            Assert.That(jsonResp.Where(x => ((JObject)x).ContainsKey("Revit") || ((JObject)x).ContainsKey("Civil3D")).Any(), Is.EqualTo(true));
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

`GetCompatibilityMap` should call the /host_map route on package manager and return host mapping in Greg.

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@DynamoDS/dynamo 

### FYIs

@dnenov 
