### PR TITLE
DYN-10211: Update pipeline.yml to migrate pipeline to CBCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dynamo Package Manager Client
 
+[![Build Status](https://c007.cloudbees-ci.autodesk.com/buildStatus/icon?job=DYNCI%2FDynamo%2FPackageManagerClient%2Fmaster)](https://c007.cloudbees-ci.autodesk.com/job/DYNCI/job/Dynamo/job/PackageManagerClient/job/master/)
+
 [![Nuget](https://img.shields.io/nuget/v/Greg?logo=nuget)](https://www.nuget.org/packages/Greg/)
 
 [![Build](https://github.com/DynamoDS/PackageManagerClient/actions/workflows/build.yml/badge.svg)](https://github.com/DynamoDS/PackageManagerClient/actions/workflows/build.yml)

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,6 +1,6 @@
 version: 0.1.1
 env:
-  - JENKINS_NODE_WIN: "CDA-VS22-SVC"
+  - JENKINS_NODE_WIN: "CDA-VS22-CBCI-SVC"
   - SLACK_QUANTUM_BUILD_CHANNEL: "#dynamo-jenkinsbuild"
   - SLACK_QUANTUM_BUILD_CREDENTIAL_ID: "slack-notify-token"
   - MAIL_QUANTUM_BUILD_RECIPIENT: "dynamo.dev@autodesk.com"


### PR DESCRIPTION
## Summary
- Update `JENKINS_NODE_WIN` from `CDA-VS22-SVC` to `CDA-VS22-CBCI-SVC` in pipeline.yml
- Add CloudBees CI build status badge to README.md

## Details
- **Pipeline OS**: Windows
- **JENKINS_NODE_WIN**: CDA-VS22-SVC → CDA-VS22-CBCI-SVC
- **Branch**: dyn-10211
- README badge: Added (no previous Jenkins badge existed)

[Dynamo CI CD on CBCI](https://autodesk.atlassian.net/wiki/x/PpPFGQ)